### PR TITLE
Display all connections when search query is empty

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -60,10 +60,12 @@
 				<false/>
 				<key>alfredfiltersresultsmatchmode</key>
 				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>escaping</key>
 				<integer>127</integer>
 				<key>keyword</key>
@@ -79,9 +81,9 @@
 				<key>runningsubtext</key>
 				<string>Searching connections for "{query}"...</string>
 				<key>script</key>
-				<string>php tableplus.php "{query}"</string>
+				<string>php tableplus.php "$1"</string>
 				<key>scriptargtype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>
@@ -98,7 +100,7 @@
 			<key>uid</key>
 			<string>7B86D057-DA8E-4302-AF17-83B889B48EE2</string>
 			<key>version</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 	</array>
 	<key>readme</key>

--- a/tableplus.php
+++ b/tableplus.php
@@ -21,7 +21,7 @@ $setapp_groups_path = $_SERVER['HOME'] . '/Library/Application Support/com.tinya
 $connections = $plist->plistToArray(file_exists($setapp_connections_path) ? $setapp_connections_path : $default_connections_path);
 $groups = $plist->plistToArray(file_exists($setapp_groups_path) ? $setapp_groups_path : $default_groups_path);
 
-$results = array_filter($connections, function ($connection) use ($query) {
+$results = empty($query) ? $connections : array_filter($connections, function ($connection) use ($query) {
     return strpos(strtolower($connection['ConnectionName']), strtolower($query)) !== false;
 });
 


### PR DESCRIPTION
Hey there, thanks for the workflow!

This PR makes the search argument optional. When no argument is provided, all connections will be listed (this is how similar workflows [alfred-vscode](https://github.com/kbshl/alfred-vscode) and [tower-alfred-workflow](https://github.com/cjlucas/tower-alfred-workflow) behave).

It also changes the preference "with input as {query}" to "with input as argv" which allows me to search for special characters in connection names, like `(`.