### PR TITLE
Fix issue if there are no groups in Table Plus.

### DIFF
--- a/tableplus.php
+++ b/tableplus.php
@@ -38,8 +38,11 @@ $urls = [];
 foreach ($results as $result) {
     $connection = $result;
 
-    $groupKey = array_search($connection['GroupID'], array_column($groups, 'ID'));
-    $group = $groups[$groupKey];
+    unset($group, $groupKey);
+    if (!empty($groups)) {
+        $groupKey = array_search($connection['GroupID'], array_column($groups, 'ID'));
+        if ($groupKey !== false) $group = $groups[$groupKey];
+    }
 
     $url = 'tableplus://?id=' . sprintf($connection['ID']);
 
@@ -51,7 +54,7 @@ foreach ($results as $result) {
 
     $title = "{$connection['ConnectionName']} » {$connection['Driver']}";
 
-    $text = "{$group['Name']} » {$connection['Enviroment']}";
+    $text = empty($group) ? "{$connection['Enviroment']}" : "{$group['Name']} » {$connection['Enviroment']}";
 
     $title = strip_tags(html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 


### PR DESCRIPTION
There is an issue which occurs when there aren't any groups in tableplus which prevents the `tp` command from returning any output (please see debug info below).

This PR checks if there are any groups found in the  `ConnectionGroups.plist` before obtaining the `$groupKey` and then setting the `$group` for the looped result.

In addition, if no group is present for the looped result, the `$text` will only contain the Environment without the Group Name

The Debug (fixed) below shows the expected output. 

Let me know if you want any change made to this PR and thanks for creating the workflow in the first place :)

Debug (issue):
```
[10:26:09.545] Logging Started...
[10:26:11.653] TablePlus[Script Filter] Queuing argument ''
[10:26:11.814] TablePlus[Script Filter] Script with argv '' finished
[10:26:11.815] STDERR: TablePlus[Script Filter] PHP Notice:  Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42
PHP Notice:  Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54
PHP Notice:  Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42
PHP Notice:  Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54
PHP Notice:  Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42
PHP Notice:  Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54
PHP Notice:  Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42
PHP Notice:  Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54
[10:26:11.820] TablePlus[Script Filter] Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54

Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54

Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54

Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54
{"items":[{"arg":"tableplus:\/\/?id=18A1BBC7-203A-4909-BA71-392341247B0B","autocomplete":"Localhost \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=18A1BBC7-203A-4909-BA71-392341247B0B","subtitle":" \u00bb local","title":"Localhost \u00bb MySQL","uid":"18A1BBC7-203A-4909-BA71-392341247B0B","valid":true},{"arg":"tableplus:\/\/?id=7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","autocomplete":"iets.local \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","subtitle":" \u00bb production","title":"iets.local \u00bb MySQL","uid":"7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","valid":true},{"arg":"tableplus:\/\/?id=4CFF5FB0-2764-4F23-8609-E025878B9104","autocomplete":"iets.local \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=4CFF5FB0-2764-4F23-8609-E025878B9104","subtitle":" \u00bb staging","title":"iets.local \u00bb MySQL","uid":"4CFF5FB0-2764-4F23-8609-E025878B9104","valid":true},{"arg":"tableplus:\/\/?id=D86AC70E-4BB9-4B09-B3C3-4C45953A986E","autocomplete":"oets \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=D86AC70E-4BB9-4B09-B3C3-4C45953A986E","subtitle":" \u00bb local","title":"oets \u00bb MySQL","uid":"D86AC70E-4BB9-4B09-B3C3-4C45953A986E","valid":true}]}
[10:26:11.822] ERROR: TablePlus[Script Filter] JSON error: JSON text did not start with array or object and option to allow fragments not set. around line 1, column 0. in JSON:
Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54

Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54

Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54

Notice: Undefined offset: 0 in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 42

Notice: Trying to access array offset on value of type null in /Users/CryDeTaan/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.92C570E4-CBA5-42B6-A747-D4CE48DA80D7/tableplus.php on line 54
{"items":[{"arg":"tableplus:\/\/?id=18A1BBC7-203A-4909-BA71-392341247B0B","autocomplete":"Localhost \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=18A1BBC7-203A-4909-BA71-392341247B0B","subtitle":" \u00bb local","title":"Localhost \u00bb MySQL","uid":"18A1BBC7-203A-4909-BA71-392341247B0B","valid":true},{"arg":"tableplus:\/\/?id=7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","autocomplete":"iets.local \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","subtitle":" \u00bb production","title":"iets.local \u00bb MySQL","uid":"7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","valid":true},{"arg":"tableplus:\/\/?id=4CFF5FB0-2764-4F23-8609-E025878B9104","autocomplete":"iets.local \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=4CFF5FB0-2764-4F23-8609-E025878B9104","subtitle":" \u00bb staging","title":"iets.local \u00bb MySQL","uid":"4CFF5FB0-2764-4F23-8609-E025878B9104","valid":true},{"arg":"tableplus:\/\/?id=D86AC70E-4BB9-4B09-B3C3-4C45953A986E","autocomplete":"oets \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=D86AC70E-4BB9-4B09-B3C3-4C45953A986E","subtitle":" \u00bb local","title":"oets \u00bb MySQL","uid":"D86AC70E-4BB9-4B09-B3C3-4C45953A986E","valid":true}]}
```

Debug (fixed):
```
[10:34:29.933] TablePlus[Script Filter] Queuing argument ''
[10:34:30.095] TablePlus[Script Filter] Script with argv '' finished
[10:34:30.098] TablePlus[Script Filter] {"items":[{"arg":"tableplus:\/\/?id=18A1BBC7-203A-4909-BA71-392341247B0B","autocomplete":"Localhost \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=18A1BBC7-203A-4909-BA71-392341247B0B","subtitle":"local","title":"Localhost \u00bb MySQL","uid":"18A1BBC7-203A-4909-BA71-392341247B0B","valid":true},{"arg":"tableplus:\/\/?id=7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","autocomplete":"iets.local \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","subtitle":"production","title":"iets.local \u00bb MySQL","uid":"7E3D5BDD-A7C0-48AA-8046-1E978F3F8F6F","valid":true},{"arg":"tableplus:\/\/?id=4CFF5FB0-2764-4F23-8609-E025878B9104","autocomplete":"iets.local \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=4CFF5FB0-2764-4F23-8609-E025878B9104","subtitle":"staging","title":"iets.local \u00bb MySQL","uid":"4CFF5FB0-2764-4F23-8609-E025878B9104","valid":true},{"arg":"tableplus:\/\/?id=D86AC70E-4BB9-4B09-B3C3-4C45953A986E","autocomplete":"oets \u00bb MySQL","quicklookurl":"tableplus:\/\/?id=D86AC70E-4BB9-4B09-B3C3-4C45953A986E","subtitle":"local","title":"oets \u00bb MySQL","uid":"D86AC70E-4BB9-4B09-B3C3-4C45953A986E","valid":true}]}
```